### PR TITLE
Look for python 2.7 libs - Fixes #3

### DIFF
--- a/src/Python/CMakeLists.txt
+++ b/src/Python/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/src/Python)
 
-find_package(PythonLibs REQUIRED)
+find_package(PythonLibs 2.7 REQUIRED)
 
 find_package(NumPy REQUIRED)
 


### PR DESCRIPTION
I had the same problem as #3 - Turns out it was because [`PyInt_FromLong` has been changed to `PyLong_FromLong`](http://python3porting.com/cextensions.html) in python 3.

I don't know if you want to be compatible with python 3, but the easiest fix for now is to specifically search for 2.7 in cmake
